### PR TITLE
Reduce bundle size

### DIFF
--- a/benchmarks/traversal-shallow-benchmark.ts
+++ b/benchmarks/traversal-shallow-benchmark.ts
@@ -1,4 +1,4 @@
-import { forIn } from 'lodash';
+import forIn from 'lodash.forin';
 import benchmark from './benchmark';
 
 const schema = require('./../resources/temando.swagger.json');

--- a/benchmarks/traversal-shallow-benchmark.ts
+++ b/benchmarks/traversal-shallow-benchmark.ts
@@ -1,4 +1,4 @@
-import forIn from 'lodash.forin';
+import * as forIn from 'lodash.forin';
 import benchmark from './benchmark';
 
 const schema = require('./../resources/temando.swagger.json');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "Brendan Abbott <brendan@bloodbone.ws>"
   ],
   "main": "dist/index.js",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "benchmark": "./scripts/benchmark",
     "build": "npm run build:source && npm run build:docs",
@@ -34,8 +37,8 @@
     "@types/chai": "^3.5.2",
     "@types/chalk": "^0.4.31",
     "@types/clone": "^0.1.30",
-    "@types/lodash": "^4.14.68",
     "@types/jest": "^20.0.6",
+    "@types/lodash": "^4.14.68",
     "@types/node": "^7.0.21",
     "ajv": "^4.9.0",
     "benchmark": "^2.1.4",
@@ -54,6 +57,9 @@
     "typescript": "^2.3.3"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash.forin": "^4.4.0",
+    "lodash.has": "^4.5.2",
+    "lodash.isobject": "^3.0.2",
+    "lodash.merge": "^4.6.0"
   }
 }

--- a/src/dereference.ts
+++ b/src/dereference.ts
@@ -29,7 +29,9 @@
 //
 // ## Dependencies
 
-import { forIn, isObject, merge } from 'lodash';
+import forIn from 'lodash.forin';
+import isObject from 'lodash.isobject';
+import merge from 'lodash.merge';
 import { get, isPointer, set } from './index';
 
 // ## Implementation
@@ -45,6 +47,9 @@ import { get, isPointer, set } from './index';
 // * Caching of schema lookups.
 // * Cleaner and more modular design of codebase. It is ok to sacrifice
 //   performance for this.
+
+const isHttp: RegExp = /^http/;
+const isRemoteRef = (ref: string): boolean => isHttp.test(ref);
 
 export const dereference: Jst.dereference = (root, resolver) => {
   // ### JSON In, JSON Out
@@ -126,7 +131,7 @@ export const dereference: Jst.dereference = (root, resolver) => {
             // Here we resolve a JSON reference (uri). In order to do so
             // correctly we must make a distinction between external
             // references and internal (circular) references.
-            if (value.indexOf('http') === 0) {
+            if (isRemoteRef(value)) {
               if (!resolve) {
                 throw new TypeError(
                   'argument: resolver is required to dereference a json uri.');

--- a/src/dereference.ts
+++ b/src/dereference.ts
@@ -29,9 +29,9 @@
 //
 // ## Dependencies
 
-import forIn from 'lodash.forin';
-import isObject from 'lodash.isobject';
-import merge from 'lodash.merge';
+import * as forIn from 'lodash.forin';
+import * as isObject from 'lodash.isobject';
+import * as merge from 'lodash.merge';
 import { get, isPointer, set } from './index';
 
 // ## Implementation

--- a/src/get.ts
+++ b/src/get.ts
@@ -25,7 +25,7 @@
 //
 // ## Dependencies
 
-import { has } from 'lodash';
+import has from 'lodash.has';
 
 // #### Implementation
 

--- a/src/get.ts
+++ b/src/get.ts
@@ -25,7 +25,7 @@
 //
 // ## Dependencies
 
-import has from 'lodash.has';
+import * as has from 'lodash.has';
 
 // #### Implementation
 

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,4 +1,4 @@
-import { has } from 'lodash';
+import has from 'lodash.has';
 
 export const set: Jst.setPointer = (obj, pointer, value) => {
 

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,4 +1,4 @@
-import has from 'lodash.has';
+import * as has from 'lodash.has';
 
 export const set: Jst.setPointer = (obj, pointer, value) => {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,13 +1620,29 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.forin@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-4.4.0.tgz#5d3f20ae564011fbe88381f7d98949c9c9519731"
+
 lodash.get@^4.1.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash.has@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+
 lodash.isequal@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+
+lodash.merge@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
 lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.7.0, lodash@^4.8.0:
   version "4.17.4"


### PR DESCRIPTION
- Cherry pick in individual lodash modules, Typescript doesn't do tree shaking, so we're actually pulling in all of lodash.
- Make use of [npm files](https://docs.npmjs.com/files/package.json#files) property to reduce the bundle size. This means on the `/dist` directory will be packaged up, previously we include the whole project (so resources, tests, etc.). You can use `npm pack` to see the difference in the distributed bundle!