### PR TITLE
Allow resolver to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.0] - 2017-08-14
 
-### Change
+### Changed
 - Re-factored code to typescript.
 - use `isPointer` internally now.
 - Now exports an optimized `npm pack` with minimal file system foot-print.
@@ -15,12 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improved package scripts, now cleaner and more verbose.
 - Simplify package scripts without losing any functionality.
 
-### Remove
+### Removed
 - Object manipulation functionality has been dropped from JST (the `merge`,
   `contains`, `iterate` functions). We now use `lodash` instead.
 - The `Validator` class has been removed, roll this out yourselves.
 
-### Add
+### Added
 - A changelog!
 - Comprehensive benchmark suite for all internal functionality.
 - Json pointer `get` and `set` functions.
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `lint` step to `travis-ci.yml`
 - `benchmark` step to `travis-ci.yml`
 
-### Fix
+### Fixed
 - `dereference` circular schema dereferencing.
 - fixed linting
 - `lodash` imports, build size reduced.

--- a/src/__tests__/dereference.test.ts
+++ b/src/__tests__/dereference.test.ts
@@ -82,4 +82,36 @@ describe('dereference schema utility function', () => {
     expect(ast).to.be.an('object');
     expect(ast.properties.circular.properties.circle.id).to.eq('http://footown.com/generic/circular#');
   });
+
+  it('dereferences without a resolver', () => {
+    const schema = require('./fixture/profile+v1.schema.json');
+
+    const ast: any = dereference(schema);
+    expect(ast).to.be.an('object');
+    expect(ast.properties.profile).deep.eq({
+      type: 'object',
+      properties: {
+        avatarUrl: {
+          description: 'The url that the users avatar can be found on',
+          type: 'string',
+          format: 'uri',
+        },
+        pictures: {
+          type: 'array',
+          items: [
+            {
+              type: 'string',
+              format: 'uri',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('fails when attempting to dereference remote references without a resolver', () => {
+    const schema = require('./fixture/address+v1.schema.json');
+
+    expect(() => dereference(schema)).to.throw('argument: resolver is required to dereference a json uri.');
+  });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,7 @@ export type Resolver = (schemaId: string) => object | undefined;
 // Reference Draft v3
 // Specification](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03).
 export type Dereferencer =
-  (schema: object | any[], resolve: Resolver) => object | any[];
+  (schema: object | any[], resolve?: Resolver) => object | any[];
 
 // A **Getter** function dereferences a JSON pointer in accordance with the
 // [IETF RFC6901 specification](https://tools.ietf.org/html/rfc6901)


### PR DESCRIPTION
The `resolver` arg on `dereference` is only required when dealing with schema that have remote references. 

This PR relaxes the type to reflect that, and adds tests to ensure the function behaves how we expect to it when it's omitted.